### PR TITLE
Increase default job_cache_ttl and job_cache_size

### DIFF
--- a/src/ivcap_ai_tool/executor.py
+++ b/src/ivcap_ai_tool/executor.py
@@ -49,8 +49,8 @@ class IvcapResult(BinaryResult):
 T = TypeVar('T')
 
 class ExecutorOpts(BaseModel):
-    job_cache_size: Optional[int] = Field(1000, description="size of job cache")
-    job_cache_ttl: Optional[int] = Field(600, description="TTL of job entries in the job cache")
+    job_cache_size: Optional[int] = Field(10000, description="size of job cache")
+    job_cache_ttl: Optional[int] = Field(3600, description="TTL of job entries in the job cache")
     max_workers: Optional[int] = Field(None, description="size of thread pool to use. If None, a new thread pool will be created for each execution")
 
 class ExecutionError(BaseModel):


### PR DESCRIPTION
This is a minimal PR to increase the default cache size values in `ExecutorOpts`.

Why? Jobs run by our existing apps which use `ivcap_ai_tool` (2 out of 3) often run longer than 10mins (which then result in a 404 being returned to the client awaiting their result).

Therefore we should provide a default TTL which caters to common requirements.

I am submitting this PR as a _subset_ of https://github.com/ivcap-works/ivcap-ai-tool-sdk-python/pull/2, because I'd like to expedite this TTL change so we have time for testing before upcoming demos.